### PR TITLE
VP8 lossy codec support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,9 @@
             "id": "image",
             "type": "pickString",
             "options": [
+                "lossy/tree.webp",
+                "lossy/fire.webp",
+                "lossy/rose.webp",
                 "lossless/rose.webp",
                 "lossless/tux.webp",
                 "lossless/dice.webp",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(JEBP_WERROR "Treat warnings as errors" ${jebp_release})
 option(JEBP_SANITIZE "Enable sanitizers" ${jebp_debug})
 option(JEBP_STDIO "Enable I/O support" ON)
 option(JEBP_SIMD "Enable SIMD optimizations" ON)
+option(JEBP_VP8 "Enable VP8 support" ON)
 option(JEBP_VP8L "Enable VP8L support" ON)
 
 # Utility functions
@@ -70,6 +71,9 @@ if(NOT JEBP_SIMD)
 endif()
 if(NOT JEBP_VP8L)
     add_compile_definitions(JEBP_NO_VP8L)
+endif()
+if(NOT JEBP_VP8)
+    add_compile_definitions(JEBP_NO_VP8)
 endif()
 
 # Demo program

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 Don't let all the [files](#what-are-all-these-files) scare you away, infact only
 [one header file](/jebp.h) is required to use this project.
 
-Currently this project only supports lossless (VP8L) images. This project:
-- Does not support decoding lossy files with VP8
-  ([Draft PR](https://github.com/matanui159/jebp/pull/2)).
+This is not a feature-complete WebP decoder and has the following limitations:
 - Does not support extended file-formats with VP8X.
 - Does not support VP8L lossless images with the color-indexing transform
   (palleted images).

--- a/dev/CMakeLists.txt
+++ b/dev/CMakeLists.txt
@@ -29,6 +29,11 @@ endfunction()
 if(BUILD_TESTING)
     add_executable(jebptest jebptest.c)
     target_link_libraries(jebptest PRIVATE ${link_options})
+    # TODO: adding these for now so I don't get any regressions, but these will
+    #       need to change when I add the deblocking filters
+    add_test_image(lossy_tree lossy/tree.webp 1024x772 84d87470)
+    add_test_image(lossy_fire lossy/fire.webp 1024x752 3e8c182b)
+    add_test_image(lossy_rose lossy/rose.webp 512x384 1cb94230)
     add_test_image(lossless_rose lossless/rose.webp 512x384 943882e6)
     add_test_image(lossless_tux lossless/tux.webp 386x395 dd77ded2)
     add_test_image(lossless_dice lossless/dice.webp 800x600 f3285d5a)

--- a/dev/credits.md
+++ b/dev/credits.md
@@ -1,4 +1,17 @@
-### [`lossless/rose.webp`](lossless/rose.webp)
+### [`lossy/tree.webp`](lossy/tree.webp)
+Image: "A Wild Cherry (Prunus avium) in flower" \
+Image Author: Benjamin Gimmel \
+[JPEG source](https://upload.wikimedia.org/wikipedia/commons/5/57/Frühling_blühender_Kirschenbaum.jpg) \
+Photo licensed under the [Creative Commons][cc] [Attribution-Share Alike 3.0 Unported][by-sa] license.
+
+### [`lossy/fire.webp`](lossy/fire.webp)
+Image: Fire breathing "Jaipur Maharaja Brass Band" Chassepierre Belgium \
+Author: Luc Viatour \
+[JPEG source](https://upload.wikimedia.org/wikipedia/commons/0/02/Fire_breathing_2_Luc_Viatour.jpg) \
+Photo licensed under the [Creative Commons][cc] [Attribution-Share Alike 3.0 Unported][by-sa] license. \
+Author website at [www.lucnix.be](https://www.lucnix.be/)
+
+### [`lossy/rose.webp`](lossy/rose.webp), [`lossless/rose.webp`](lossless/rose.webp)
 "Free Stock Photo in High Resolution - Yellow Rose 3 - Flowers" \
 Image Author: Jon Sullivan \
 This file is in the public domain. \

--- a/dev/lossy/fire.webp
+++ b/dev/lossy/fire.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51c2f158656bda1491a482b01c6137bdc2160d649a1d6e1e8b5f2ceb211c7e9b
+size 86722

--- a/dev/lossy/rose.webp
+++ b/dev/lossy/rose.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa6da4f967e6690369812b2aa5cbd612cb5bcea9fa3f80f10b114cba4be8c3a5
+size 17836

--- a/dev/lossy/tree.webp
+++ b/dev/lossy/tree.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ab672d8d00f77bb9a4195fab3be831fedd9bb75c42f009859acdd01d5969480
+size 178494

--- a/jebp.h
+++ b/jebp.h
@@ -1713,10 +1713,10 @@ static void jebp__b_pred_tm(jebp_ubyte *pred, jebp_int stride, jebp_ubyte *tr) {
     uint8x16_t v_add = vqaddq_u8(v_left, v_diff);
     uint8x16_t v_sub = vqsubq_u8(v_left, v_diff);
     uint32x4_t v_row = vreinterpretq_u32_u8(vbslq_u8(v_neg, v_sub, v_add));
-    vst1q_lane_u32(&pred[0 * stride], v_row, 0);
-    vst1q_lane_u32(&pred[1 * stride], v_row, 1);
-    vst1q_lane_u32(&pred[2 * stride], v_row, 2);
-    vst1q_lane_u32(&pred[3 * stride], v_row, 3);
+    vst1q_lane_u32((uint32_t *)&pred[0 * stride], v_row, 0);
+    vst1q_lane_u32((uint32_t *)&pred[1 * stride], v_row, 1);
+    vst1q_lane_u32((uint32_t *)&pred[2 * stride], v_row, 2);
+    vst1q_lane_u32((uint32_t *)&pred[3 * stride], v_row, 3);
 #else
     for (jebp_int y = 0; y < JEBP__BLOCK_SIZE; y += 1) {
         jebp_ubyte *row = &pred[y * stride];

--- a/jebp.h
+++ b/jebp.h
@@ -390,7 +390,7 @@ jebp_error_t jebp_read(jebp_image_t *image, const char *path);
 #if JEBP__HAS_ATTRIBUTE(aligned)
 #define JEBP__ALIGN_TYPE(type, align) type __attribute__((aligned(align)))
 #elif defined(_MSC_VER)
-#define JEBP__ALIGN_TYPE(type, align) __declspec(align(align)) type
+#define JEBP__ALIGN_TYPE(type, aligned) __declspec(align(aligned)) type
 #else
 #define JEBP__ALIGN_TYPE(type, align) type
 #endif


### PR DESCRIPTION
- [x] raw header and image size
- [x] boolean entropy-coder
- [x] compressed header
- [x] read prediction modes (macroblock header)
- [x] DCT & WHT coefficients
- [x] basic prediction modes
- [x] independent prediction modes
- [ ] loop filters

Will try and keep an updated list of features that I am skipping during development to potentially add later ("currently unsupported"):
- frame upscaling (section 9.1). not sure if its worth supporting this since I don't think many images would use it. maybe it should just be ignored and the image returned at the encoded resolution, if the user knows there is upscaling (maybe through API? but unlikely. keeping API small) they can upscale themselves using their own method that would probably be faster and better quality than whatever I could come up with.
- filter adjustments (section 9.4). I can't seem to get `cwebp` to generate them anyway
- data partitions (section 9.5). There is a way to force `cwebp` to do it and on initial look it may do it automatically if the file is too large, TODO: add large image test
- Coefficient skipping (section 11.1). Should be easy to support just lazy and my test image doesn't have it